### PR TITLE
Translate resource ID strings to actual strings

### DIFF
--- a/mdpreference/src/main/java/io/github/xhinliang/mdpreference/DialogPreference.java
+++ b/mdpreference/src/main/java/io/github/xhinliang/mdpreference/DialogPreference.java
@@ -25,12 +25,10 @@ public abstract class DialogPreference extends Preference {
     protected Dialog mDialog;
 
     private void init(Context context, AttributeSet attrs) {
-        mDialogTitle = getAndroidAttribute(attrs, "dialogTitle", (String) getTitle());
-        mDialogMessage = getAndroidAttribute(attrs, "dialogMessage", null);
-        mPositiveButtonText = getAndroidAttribute(attrs, "positiveButtonText",
-                (String) context.getText(R.string.confirm));
-        mNegativeButtonText = getAndroidAttribute(attrs, "negativeButtonText",
-                (String) context.getText(R.string.cancel));
+        mDialogTitle = getStringAttribute(attrs, "dialogTitle", (String) getTitle());
+        mDialogMessage = getStringAttribute(attrs, "dialogMessage", null);
+        mPositiveButtonText = getStringAttribute(attrs, "positiveButtonText", context.getString(android.R.string.ok));
+        mNegativeButtonText = getStringAttribute(attrs, "negativeButtonText", context.getString(android.R.string.cancel));
     }
 
     public DialogPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {

--- a/mdpreference/src/main/java/io/github/xhinliang/mdpreference/Preference.java
+++ b/mdpreference/src/main/java/io/github/xhinliang/mdpreference/Preference.java
@@ -109,10 +109,37 @@ public class Preference extends android.preference.Preference {
         this.icon = icon;
     }
 
-    public String getAndroidAttribute(AttributeSet attrs, String name, String defaultValue) {
-        if (attrs == null || attrs.getAttributeValue("http://schemas.android.com/apk/res/android", name) == null)
-            return defaultValue;
-        else
+    public String getAndroidAttribute(AttributeSet attrs, String name) {
+        if (attrs.getAttributeValue("http://schemas.android.com/apk/res/android", name) != null)
             return attrs.getAttributeValue("http://schemas.android.com/apk/res/android", name);
+        return null;
+    }
+
+
+    /**
+     * Get a resource ID from a string
+     * @link https://github.com/android/platform_frameworks_base/blob/master/libs/androidfw/ResourceTypes.cpp#L62
+     */
+    public int formatResourceId(String value) {
+        if (value != null && value.matches("^@[0-9]+$")) {
+            // A valid resource ID string starts with "@" and is followed by an integer whose first two bytes are either 0x01 or 0x07
+            int resId = Integer.parseInt(value.substring(1, value.length()), 10);
+            if (Integer.toHexString(resId).length() != 8 || resId >> 24 != 0x01 || resId >> 24 != 0x7f) {
+                return resId;
+            }
+        }
+        return -1;
+    }
+
+    public String getStringAttribute(AttributeSet attrs, String name, String defaultValue) {
+        String value = getAndroidAttribute(attrs, name);
+        if (value == null) {
+            return defaultValue;
+        }
+        int resId = formatResourceId(value);
+        if (resId == -1) {
+            return value;
+        }
+        return getContext().getString(resId);
     }
 }

--- a/mdpreference/src/main/res/values/strings.xml
+++ b/mdpreference/src/main/res/values/strings.xml
@@ -1,5 +1,3 @@
 <resources>
     <string name="app_name">MaterialPreference</string>
-    <string name="cancel">Cancel</string>
-    <string name="confirm">Confirm</string>
 </resources>


### PR DESCRIPTION
修复了上次提交时没有注意到的问题：当dialogTitle等属性值为Resource ID时，实际的字符串显示成了Resource ID的形式。
![qq 20160321102330](https://cloud.githubusercontent.com/assets/8849362/13909472/00bcb3dc-ef4f-11e5-8601-412d8ae55c80.png)

另外使用系统自带的字符串替换掉了自定义的`cancel`和`confirm`字符串。
