### PR TITLE
Fix null summary selection error for EditTextPreference

### DIFF
--- a/mdpreference/src/main/java/io/github/xhinliang/mdpreference/EditTextPreference.java
+++ b/mdpreference/src/main/java/io/github/xhinliang/mdpreference/EditTextPreference.java
@@ -79,7 +79,7 @@ public class EditTextPreference extends DialogPreference {
         final Dialog dialog = mDialog = mBuilder.build(getContext());
         EditText editText = (com.rey.material.widget.EditText) dialog.findViewById(R.id.custom_et);
         editText.setText(getSummary());
-        editText.setSelection(getSummary().length());
+        editText.setSelection(getSummary() == null ? 0 : getSummary().length());
         if (state != null) {
             dialog.onRestoreInstanceState(state);
         }


### PR DESCRIPTION
当EditTextPreference没有设置`android:summary`属性，并且程序的`pref.xml`中也没有相应的键值时，会导致`getSummary()`结果为`null`，进而导致`editText.setSelection()`空指针异常。
