### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/material/src/main/java/com/rey/material/util/ColorUtil.java
+++ b/material/src/main/java/com/rey/material/util/ColorUtil.java
@@ -4,6 +4,8 @@ import android.graphics.Color;
 
 public class ColorUtil {
 
+	private ColorUtil() {}
+
 	private static int getMiddleValue(int prev, int next, float factor){
 		return Math.round(prev + (next - prev) * factor);
 	}
@@ -30,4 +32,5 @@ public class ColorUtil {
 		
 		return (baseColor & 0x00FFFFFF) | (alpha << 24);
 	}
+
 }

--- a/material/src/main/java/com/rey/material/util/ThemeUtil.java
+++ b/material/src/main/java/com/rey/material/util/ThemeUtil.java
@@ -13,6 +13,8 @@ public class ThemeUtil {
 
     private static TypedValue value;
 
+    private ThemeUtil() {}
+
     public static int dpToPx(Context context, int dp) {
         return (int) (TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, context.getResources().getDisplayMetrics()) + 0.5f);
     }

--- a/material/src/main/java/com/rey/material/util/ViewUtil.java
+++ b/material/src/main/java/com/rey/material/util/ViewUtil.java
@@ -20,9 +20,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class ViewUtil {
 	
-	public static final long FRAME_DURATION = 1000 / 60;
+    public static final long FRAME_DURATION = 1000 / 60;
 
-	private static final AtomicInteger sNextGeneratedId = new AtomicInteger(1);
+    private static final AtomicInteger sNextGeneratedId = new AtomicInteger(1);
+
+    private ViewUtil() {}
 
     @SuppressLint("NewApi")
     public static int generateViewId() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava
