### PR TITLE
Multiple code improvements - squid:UselessParenthesesCheck, squid:S1066, squid:SwitchLastCaseIsDefaultCheck

### DIFF
--- a/material/src/main/java/com/rey/material/util/ToolbarManager.java
+++ b/material/src/main/java/com/rey/material/util/ToolbarManager.java
@@ -257,9 +257,8 @@ public class ToolbarManager {
         ActionMenuView menuView = getMenuView();
         for(int i = 0, count = menuView == null ? 0 : menuView.getChildCount(); i < count; i++){
             View child = menuView.getChildAt(i);
-            if(mRippleStyle != 0){
-                if(child.getBackground() == null || !(child.getBackground() instanceof ToolbarRippleDrawable))
-                    ViewUtil.setBackground(child, getBackground());
+            if(mRippleStyle != 0 && (child.getBackground() == null || !(child.getBackground() instanceof ToolbarRippleDrawable))){
+                ViewUtil.setBackground(child, getBackground());
             }
         }
 
@@ -280,9 +279,8 @@ public class ToolbarManager {
             View child = menuView.getChildAt(i);
             Animation anim = mAnimator.getOutAnimation(child, i);
             mAnimations.add(anim);
-            if(anim != null)
-                if(slowestAnimation == null || slowestAnimation.getStartOffset() + slowestAnimation.getDuration() < anim.getStartOffset() + anim.getDuration())
-                    slowestAnimation = anim;
+            if(anim != null && (slowestAnimation == null || slowestAnimation.getStartOffset() + slowestAnimation.getDuration() < anim.getStartOffset() + anim.getDuration()))
+                slowestAnimation = anim;
         }
 
         if(slowestAnimation == null)

--- a/material/src/main/java/com/rey/material/util/ViewUtil.java
+++ b/material/src/main/java/com/rey/material/util/ViewUtil.java
@@ -123,6 +123,8 @@ public class ViewUtil {
                         case 16:
                             v.setBackgroundTintMode(PorterDuff.Mode.ADD);
                             break;
+                        default:
+                            break;
                     }
                 }
             }
@@ -150,13 +152,13 @@ public class ViewUtil {
             else if(attr == R.styleable.View_android_paddingStart) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                     startPadding = a.getDimensionPixelSize(attr, Integer.MIN_VALUE);
-                    startPaddingDefined = (startPadding != Integer.MIN_VALUE);
+                    startPaddingDefined = startPadding != Integer.MIN_VALUE;
                 }
             }
             else if(attr == R.styleable.View_android_paddingEnd) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                     endPadding = a.getDimensionPixelSize(attr, Integer.MIN_VALUE);
-                    endPaddingDefined = (endPadding != Integer.MIN_VALUE);
+                    endPaddingDefined = endPadding != Integer.MIN_VALUE;
                 }
             }
             else if(attr == R.styleable.View_android_fadeScrollbars)
@@ -196,6 +198,8 @@ public class ViewUtil {
                     case 0x03000000:
                         v.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_INSET);
                         break;
+                    default:
+                        break;
                 }
             }
             else if(attr == R.styleable.View_android_soundEffectsEnabled)
@@ -225,6 +229,8 @@ public class ViewUtil {
                         case 6:
                             v.setTextAlignment(View.TEXT_ALIGNMENT_VIEW_END);
                             break;
+                        default:
+                            break;
                     }
                 }
             }
@@ -250,6 +256,8 @@ public class ViewUtil {
                         case 5:
                             v.setTextDirection(View.TEXT_DIRECTION_LOCALE);
                             break;
+                        default:
+                            break;
                     }
                 }
             }
@@ -264,6 +272,8 @@ public class ViewUtil {
                         break;
                     case 2:
                         v.setVisibility(View.GONE);
+                        break;
+                    default:
                         break;
                 }
             }
@@ -283,14 +293,14 @@ public class ViewUtil {
                         case 3:
                             v.setLayoutDirection(View.LAYOUT_DIRECTION_LOCALE);
                             break;
+                        default:
+                            break;
                     }
                 }
             }
-            else if(attr == R.styleable.View_android_src){
-                if(v instanceof ImageView){
-                    int resId = a.getResourceId(attr, 0);
-                    ((ImageView)v).setImageResource(resId);
-                }
+            else if(attr == R.styleable.View_android_src && v instanceof ImageView){
+                int resId = a.getResourceId(attr, 0);
+                ((ImageView)v).setImageResource(resId);
             }
         }
 
@@ -406,10 +416,9 @@ public class ViewUtil {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
                         v.setLetterSpacing(appearance.getFloat(attr, 0));
 
-                } else if (attr == R.styleable.TextAppearance_android_fontFeatureSettings) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-                        v.setFontFeatureSettings(appearance.getString(attr));
-
+                } else if (attr == R.styleable.TextAppearance_android_fontFeatureSettings
+                        && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    v.setFontFeatureSettings(appearance.getString(attr));
                 }
             }
 
@@ -435,6 +444,8 @@ public class ViewUtil {
                     break;
                 case 3:
                     tf = Typeface.MONOSPACE;
+                    break;
+                default:
                     break;
             }
             v.setTypeface(tf, styleIndex);
@@ -530,10 +541,9 @@ public class ViewUtil {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
                         v.setLetterSpacing(appearance.getFloat(attr, 0));
 
-                } else if (attr == R.styleable.TextAppearance_android_fontFeatureSettings) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-                        v.setFontFeatureSettings(appearance.getString(attr));
-
+                } else if (attr == R.styleable.TextAppearance_android_fontFeatureSettings
+                        && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    v.setFontFeatureSettings(appearance.getString(attr));
                 }
             }
 
@@ -675,9 +685,9 @@ public class ViewUtil {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
                     v.setLetterSpacing(a.getFloat(attr, 0));
 
-            } else if (attr == R.styleable.TextView_android_fontFeatureSettings) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-                    v.setFontFeatureSettings(a.getString(attr));
+            } else if (attr == R.styleable.TextView_android_fontFeatureSettings
+                    && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                v.setFontFeatureSettings(a.getString(attr));
 
             }
         }
@@ -728,6 +738,8 @@ public class ViewUtil {
                     break;
                 case 3:
                     tf = Typeface.MONOSPACE;
+                    break;
+                default:
                     break;
             }
             v.setTypeface(tf, styleIndex);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1066 - Collapsible "if" statements should be merged.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava
