### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/mdpreference/src/main/java/io/github/xhinliang/mdpreference/DialogPreference.java
+++ b/mdpreference/src/main/java/io/github/xhinliang/mdpreference/DialogPreference.java
@@ -25,13 +25,6 @@ public abstract class DialogPreference extends Preference {
 
     protected Dialog mDialog;
 
-    private void init(Context context, AttributeSet attrs) {
-        mDialogTitle = getStringAttribute(attrs, "dialogTitle", (String) getTitle());
-        mDialogMessage = getStringAttribute(attrs, "dialogMessage", null);
-        mPositiveButtonText = getStringAttribute(attrs, "positiveButtonText", context.getString(android.R.string.ok));
-        mNegativeButtonText = getStringAttribute(attrs, "negativeButtonText", context.getString(android.R.string.cancel));
-    }
-
     public DialogPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
         init(context, attrs);
@@ -50,6 +43,13 @@ public abstract class DialogPreference extends Preference {
     public DialogPreference(Context context) {
         super(context);
         init(context, null);
+    }
+
+    private void init(Context context, AttributeSet attrs) {
+        mDialogTitle = getStringAttribute(attrs, "dialogTitle", (String) getTitle());
+        mDialogMessage = getStringAttribute(attrs, "dialogMessage", null);
+        mPositiveButtonText = getStringAttribute(attrs, "positiveButtonText", context.getString(android.R.string.ok));
+        mNegativeButtonText = getStringAttribute(attrs, "negativeButtonText", context.getString(android.R.string.cancel));
     }
 
     public void setDialogTitle(CharSequence dialogTitle) {
@@ -146,26 +146,6 @@ public abstract class DialogPreference extends Preference {
     }
 
     protected static class DialogSavedState extends BaseSavedState {
-        boolean isDialogShowing;
-        Bundle dialogBundle;
-
-        public DialogSavedState(Parcel source) {
-            super(source);
-            isDialogShowing = source.readInt() == 1;
-            dialogBundle = source.readBundle();
-        }
-
-        @Override
-        public void writeToParcel(Parcel dest, int flags) {
-            super.writeToParcel(dest, flags);
-            dest.writeInt(isDialogShowing ? 1 : 0);
-            dest.writeBundle(dialogBundle);
-        }
-
-        public DialogSavedState(Parcelable superState) {
-            super(superState);
-        }
-
         public static final Parcelable.Creator<DialogSavedState> CREATOR =
                 new Parcelable.Creator<DialogSavedState>() {
                     public DialogSavedState createFromParcel(Parcel in) {
@@ -176,6 +156,27 @@ public abstract class DialogPreference extends Preference {
                         return new DialogSavedState[size];
                     }
                 };
+
+        boolean isDialogShowing;
+        Bundle dialogBundle;
+
+        public DialogSavedState(Parcel source) {
+            super(source);
+            isDialogShowing = source.readInt() == 1;
+            dialogBundle = source.readBundle();
+        }
+
+        public DialogSavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeInt(isDialogShowing ? 1 : 0);
+            dest.writeBundle(dialogBundle);
+        }
+
     }
 
 }

--- a/mdpreference/src/main/java/io/github/xhinliang/mdpreference/EditTextPreference.java
+++ b/mdpreference/src/main/java/io/github/xhinliang/mdpreference/EditTextPreference.java
@@ -16,6 +16,8 @@ import com.rey.material.widget.EditText;
  * sf
  */
 public class EditTextPreference extends DialogPreference {
+    private String mText;
+
     public EditTextPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
     }
@@ -31,9 +33,6 @@ public class EditTextPreference extends DialogPreference {
     public EditTextPreference(Context context) {
         super(context);
     }
-
-
-    private String mText;
 
     public void setText(String text) {
         final boolean wasBlocking = shouldDisableDependents();
@@ -120,23 +119,6 @@ public class EditTextPreference extends DialogPreference {
 
 
     private static class SavedState extends BaseSavedState {
-        String text;
-
-        public SavedState(Parcel source) {
-            super(source);
-            text = source.readString();
-        }
-
-        @Override
-        public void writeToParcel(Parcel dest, int flags) {
-            super.writeToParcel(dest, flags);
-            dest.writeString(text);
-        }
-
-        public SavedState(Parcelable superState) {
-            super(superState);
-        }
-
         public static final Parcelable.Creator<SavedState> CREATOR =
                 new Parcelable.Creator<SavedState>() {
                     public SavedState createFromParcel(Parcel in) {
@@ -147,6 +129,23 @@ public class EditTextPreference extends DialogPreference {
                         return new SavedState[size];
                     }
                 };
+
+        String text;
+
+        public SavedState(Parcel source) {
+            super(source);
+            text = source.readString();
+        }
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeString(text);
+        }
 
     }
 }

--- a/mdpreference/src/main/java/io/github/xhinliang/mdpreference/ListPreference.java
+++ b/mdpreference/src/main/java/io/github/xhinliang/mdpreference/ListPreference.java
@@ -187,21 +187,6 @@ public class ListPreference extends DialogPreference {
     }
 
     private static class SavedState extends BaseSavedState {
-        String value;
-        public SavedState(Parcel source) {
-            super(source);
-            value = source.readString();
-        }
-        @Override
-        public void writeToParcel(Parcel dest, int flags) {
-            super.writeToParcel(dest, flags);
-            dest.writeString(value);
-        }
-
-        public SavedState(Parcelable superState) {
-            super(superState);
-        }
-
         public static final Parcelable.Creator<SavedState> CREATOR =
                 new Parcelable.Creator<SavedState>() {
                     public SavedState createFromParcel(Parcel in) {
@@ -212,5 +197,23 @@ public class ListPreference extends DialogPreference {
                         return new SavedState[size];
                     }
                 };
+
+        String value;
+
+        public SavedState(Parcel source) {
+            super(source);
+            value = source.readString();
+        }
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeString(value);
+        }
+
     }
 }

--- a/mdpreference/src/main/java/io/github/xhinliang/mdpreference/MultiSelectListPreference.java
+++ b/mdpreference/src/main/java/io/github/xhinliang/mdpreference/MultiSelectListPreference.java
@@ -20,12 +20,6 @@ public class MultiSelectListPreference extends DialogPreference {
     private boolean mValueSet;
     private int selects;
 
-    private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.list_preference, defStyleAttr, defStyleRes);
-        mEntries = a.getTextArray(R.styleable.list_preference_entry_arr);
-        a.recycle();
-    }
-
     public MultiSelectListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
         init(context, attrs, defStyleAttr, defStyleRes);
@@ -46,6 +40,11 @@ public class MultiSelectListPreference extends DialogPreference {
         init(context, null, 0, 0);
     }
 
+    private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.list_preference, defStyleAttr, defStyleRes);
+        mEntries = a.getTextArray(R.styleable.list_preference_entry_arr);
+        a.recycle();
+    }
 
     @Override
     protected void onShowDialog(Bundle state) {
@@ -186,23 +185,6 @@ public class MultiSelectListPreference extends DialogPreference {
 
 
     private static class SavedState extends BaseSavedState {
-        int value;
-
-        public SavedState(Parcel source) {
-            super(source);
-            value = source.readInt();
-        }
-
-        @Override
-        public void writeToParcel(Parcel dest, int flags) {
-            super.writeToParcel(dest, flags);
-            dest.writeInt(value);
-        }
-
-        public SavedState(Parcelable superState) {
-            super(superState);
-        }
-
         public static final Parcelable.Creator<SavedState> CREATOR =
                 new Parcelable.Creator<SavedState>() {
                     public SavedState createFromParcel(Parcel in) {
@@ -213,5 +195,22 @@ public class MultiSelectListPreference extends DialogPreference {
                         return new SavedState[size];
                     }
                 };
+
+        int value;
+
+        public SavedState(Parcel source) {
+            super(source);
+            value = source.readInt();
+        }
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeInt(value);
+        }
     }
 }

--- a/mdpreference/src/main/java/io/github/xhinliang/mdpreference/TwoStatePreference.java
+++ b/mdpreference/src/main/java/io/github/xhinliang/mdpreference/TwoStatePreference.java
@@ -238,24 +238,6 @@ public abstract class TwoStatePreference extends Preference {
     }
 
     static class SavedState extends BaseSavedState {
-
-        boolean checked;
-
-        public SavedState(Parcel source) {
-            super(source);
-            checked = source.readInt() == 1;
-        }
-
-        @Override
-        public void writeToParcel(Parcel dest, int flags) {
-            super.writeToParcel(dest, flags);
-            dest.writeInt(checked ? 1 : 0);
-        }
-
-        public SavedState(Parcelable superState) {
-            super(superState);
-        }
-
         public static final Creator<SavedState> CREATOR = new Creator<SavedState>() {
             public SavedState createFromParcel(Parcel in) {
                 return new SavedState(in);
@@ -265,6 +247,23 @@ public abstract class TwoStatePreference extends Preference {
                 return new SavedState[size];
             }
         };
+
+        boolean checked;
+
+        public SavedState(Parcel source) {
+            super(source);
+            checked = source.readInt() == 1;
+        }
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeInt(checked ? 1 : 0);
+        }
     }
 }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
